### PR TITLE
Implemented 503, 505, 418

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ LengthRequiredResult
 PreconditionFailedResult
 PreconditionFailedObjectResult
 
+// 415 Unsupported Media Type
+UnsupportedMediaTypeResult
+
+// 418 Im A Teapot
+ImATeapotResult
+
 // 501 Not Implemented
 NotImplementedResult
 
@@ -130,6 +136,9 @@ controller.PreconditionFailed(someObject);
 
 // returns 415 Unsupported Media Type
 controller.UnsupportedMediaType();
+
+// returns 418 Im A Teapot
+controller.ImATeapot();
 
 // returns 501 Not Implemented
 controller.NotImplemented();

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ ServiceUnavailableResult
 
 // 504 Gateway Timeout
 GatewayTimeoutResult
+
+// 505 HTTP Version Not Supported
+HTTPVersionNotSupportedResult
 ```
 
 ### Available ControllerBase extension methods:
@@ -151,6 +154,9 @@ controller.ServiceUnavailable();
 
 // returns 504 Gateway Timeout
 controller.GatewayTimeout();
+
+// returns 505 HTTP Version Not Supported
+controller.HTTPVersionNotSupported();
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ NotImplementedResult
 // 502 Bad Gateway
 BadGatewayResult
 
+// 503 Service Unavailable
+ServiceUnavailableResult
+
 // 504 Gateway Timeout
 GatewayTimeoutResult
 ```
@@ -133,6 +136,9 @@ controller.NotImplemented();
 
 // returns 502 Bad Gateway
 controller.BadGateway();
+
+// returns 503 Service Unavailable
+controller.ServiceUnavailable();
 
 // returns 504 Gateway Timeout
 controller.GatewayTimeout();

--- a/src/AspNetCore.Mvc.HttpActionResults.ClientError.Extensions/ClientErrorControllerBaseExtensions.cs
+++ b/src/AspNetCore.Mvc.HttpActionResults.ClientError.Extensions/ClientErrorControllerBaseExtensions.cs
@@ -66,5 +66,13 @@ namespace Microsoft.AspNetCore.Mvc
         /// <returns>The created <see cref="UnsupportedMediaTypeResult"/> for the response.</returns>
         public static UnsupportedMediaTypeResult UnsupportedMediaType(this ControllerBase controller)
             => new UnsupportedMediaTypeResult();
+
+        /// <summary>
+        /// Creates an <see cref="ImATeapotResult"/> object that produces an Im a Teapot (418) response.
+        /// </summary>
+        /// <param name="controller">MVC controller instance.</param>
+        /// <returns>The created <see cref="ImATeapotResult"/> for the response.</returns>
+        public static ImATeapotResult ImATeapot(this ControllerBase controller)
+            => new ImATeapotResult();
     }
 }

--- a/src/AspNetCore.Mvc.HttpActionResults.ClientError/ImATeapotResult.cs
+++ b/src/AspNetCore.Mvc.HttpActionResults.ClientError/ImATeapotResult.cs
@@ -1,0 +1,19 @@
+﻿namespace Microsoft.AspNetCore.Mvc
+{
+    using Http;
+
+    /// <summary>
+    /// A <see cref="StatusCodeResult"/> that when executed will produce an
+    /// <see cref="StatusCodes.Status418ImATeapot"/> response.
+    /// </summary>
+    public class ImATeapotResult : StatusCodeResult
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImATeapotResult"/> class.
+        /// </summary>
+        public ImATeapotResult()
+            : base(StatusCodes.Status418ImATeapot)
+        {
+        }
+    }
+}

--- a/src/AspNetCore.Mvc.HttpActionResults.ServerError.Extensions/ServerErrorControllerBaseExtensions.cs
+++ b/src/AspNetCore.Mvc.HttpActionResults.ServerError.Extensions/ServerErrorControllerBaseExtensions.cs
@@ -45,5 +45,14 @@
         /// <returns>The created <see cref="GatewayTimeoutResult"/> for the response.</returns>
         public static GatewayTimeoutResult GatewayTimeout(this ControllerBase controller)
             => new GatewayTimeoutResult();
+
+        /// <summary>
+        /// Creates a <see cref="HTTPVersionNotSupportedResult"/> object that produces a HTTP Version Not Supported (505) response.
+        /// </summary>
+        /// <param name="controller">MVC controller instance.</param>
+        /// <param name="value">The precondition failed value to format in the entity body.</param>
+        /// <returns>The created <see cref="HTTPVersionNotSupportedResult"/> for the response.</returns>
+        public static HTTPVersionNotSupportedResult HTTPVersionNotSupported(this ControllerBase controller, object value)
+            => new HTTPVersionNotSupportedResult(value);
     }
 }

--- a/src/AspNetCore.Mvc.HttpActionResults.ServerError.Extensions/ServerErrorControllerBaseExtensions.cs
+++ b/src/AspNetCore.Mvc.HttpActionResults.ServerError.Extensions/ServerErrorControllerBaseExtensions.cs
@@ -6,7 +6,7 @@
     public static class ServerErrorControllerBaseExtensions
     {
         /// <summary>
-        /// Creates an <see cref="NotImplementedResult"/> object that produces an Not Implemented (501) response.
+        /// Creates a <see cref="NotImplementedResult"/> object that produces a Not Implemented (501) response.
         /// </summary>
         /// <param name="controller">MVC controller instance.</param>
         /// <returns>The created <see cref="NotImplementedResult"/> for the response.</returns>
@@ -14,7 +14,7 @@
             => new NotImplementedResult();
 
         /// <summary>
-        /// Creates an <see cref="BadGatewayResult"/> object that produces an Bad Getaway (502) response.
+        /// Creates a <see cref="BadGatewayResult"/> object that produces a Bad Getaway (502) response.
         /// </summary>
         /// <param name="controller">MVC controller instance.</param>
         /// <returns>The created <see cref="BadGatewayResult"/> for the response.</returns>
@@ -22,7 +22,24 @@
             => new BadGatewayResult();
 
         /// <summary>
-        /// Creates an <see cref="GatewayTimeoutResult"/> object that produces an Gateway Timeout (504) response.
+        /// Creates a <see cref="ServiceUnavailableResult"/> object that produces an empty Service Unavailable (503) response.
+        /// </summary>
+        /// <param name="controller">MVC controller instance.</param>
+        /// <returns>The created <see cref="ServiceUnavailableResult"/> for the response.</returns>
+        public static ServiceUnavailableResult ServiceUnavailable(this ControllerBase controller)
+             => new ServiceUnavailableResult();
+
+        /// <summary>
+        /// Creates a <see cref="ServiceUnavailableResult"/> object that produces a Service Unavailable (503) response.
+        /// </summary>
+        /// <param name="controller">MVC controller instance.</param>
+        /// <param name="lengthOfDelay">Length of delay after which the server will be running again.</param>
+        /// <returns>The created <see cref="ServiceUnavailableResult"/> for the response.</returns>
+        public static ServiceUnavailableResult ServiceUnavailable(this ControllerBase controller, string lengthOfDelay)
+             => new ServiceUnavailableResult(lengthOfDelay);
+
+        /// <summary>
+        /// Creates a <see cref="GatewayTimeoutResult"/> object that produces a Gateway Timeout (504) response.
         /// </summary>
         /// <param name="controller">MVC controller instance.</param>
         /// <returns>The created <see cref="GatewayTimeoutResult"/> for the response.</returns>

--- a/src/AspNetCore.Mvc.HttpActionResults.ServerError/HTTPVersionNotSupportedResult.cs
+++ b/src/AspNetCore.Mvc.HttpActionResults.ServerError/HTTPVersionNotSupportedResult.cs
@@ -1,0 +1,20 @@
+﻿namespace Microsoft.AspNetCore.Mvc
+{
+    using Http;
+
+    /// <summary>
+    /// An <see cref="ObjectResult"/> that when executed performs content negotiation, formats the entity body, and
+    /// will produce a <see cref="StatusCodes.Status505HttpVersionNotsupported"/> response if negotiation and formatting succeed.
+    /// </summary>
+    public class HTTPVersionNotSupportedResult : ObjectResult
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HTTPVersionNotSupportedResult"/> class.
+        /// </summary>
+        public HTTPVersionNotSupportedResult(object value)
+            : base(value)
+        {
+            this.StatusCode = StatusCodes.Status505HttpVersionNotsupported;
+        }
+    }
+}

--- a/src/AspNetCore.Mvc.HttpActionResults.ServerError/ServiceUnavailableResult.cs
+++ b/src/AspNetCore.Mvc.HttpActionResults.ServerError/ServiceUnavailableResult.cs
@@ -1,0 +1,48 @@
+﻿namespace Microsoft.AspNetCore.Mvc
+{
+    using Extensions.Primitives;
+    using Http;
+    using Net.Http.Headers;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// An <see cref="StatusCodeResult"/> that when executed will produce a
+    /// <see cref="StatusCodes.Status503ServiceUnavailable"/> response.
+    /// </summary>
+    public class ServiceUnavailableResult : StatusCodeResult
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServiceUnavailableResult"/> class.
+        /// </summary>
+        public ServiceUnavailableResult()
+            : base(StatusCodes.Status503ServiceUnavailable)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServiceUnavailableResult"/> class.
+        /// </summary>
+        /// <param name="lengthOfDelay">Length of delay to put in the response header.</param>
+        public ServiceUnavailableResult(string lengthOfDelay)
+            : this()
+        {
+            this.LengthOfDelay = lengthOfDelay;
+        }
+
+        /// <summary>
+        /// Gets or sets the location to put in the response header.
+        /// </summary>
+        public string LengthOfDelay { get; set; }
+
+        /// <inheritdoc />
+        public override Task ExecuteResultAsync(ActionContext context)
+        {
+            if (!string.IsNullOrWhiteSpace(this.LengthOfDelay))
+            {
+                context.HttpContext.Response.Headers.Add(HeaderNames.RetryAfter, new StringValues(this.LengthOfDelay));
+            }
+
+            return base.ExecuteResultAsync(context);
+        }
+    }
+}

--- a/src/AspNetCore.Mvc.HttpActionResults.ServerError/ServiceUnavailableResult.cs
+++ b/src/AspNetCore.Mvc.HttpActionResults.ServerError/ServiceUnavailableResult.cs
@@ -30,7 +30,7 @@
         }
 
         /// <summary>
-        /// Gets or sets the location to put in the response header.
+        /// Gets or sets the length of the delay to put in the response header.
         /// </summary>
         public string LengthOfDelay { get; set; }
 

--- a/test/AspNetCore.Mvc.HttpActionResults.ClientError.Test/ClientErrorControllerBaseExtensionsTest.cs
+++ b/test/AspNetCore.Mvc.HttpActionResults.ClientError.Test/ClientErrorControllerBaseExtensionsTest.cs
@@ -38,6 +38,17 @@
             Assert.IsAssignableFrom<RequestTimeoutResult>(result);
         }
 
+        [Fact]
+        public void ImATeapotShouldReturnImATeapotResult()
+        {
+            var controller = new HomeController();
+
+            var result = controller.TestImATeapotResult();
+
+            Assert.NotNull(result);
+            Assert.IsAssignableFrom<ImATeapotResult>(result);
+        }
+
         private class HomeController : ControllerBase
         {
             public IActionResult TestLengthRequiredResult()

--- a/test/AspNetCore.Mvc.HttpActionResults.ClientError.Test/ClientErrorControllerBaseExtensionsTest.cs
+++ b/test/AspNetCore.Mvc.HttpActionResults.ClientError.Test/ClientErrorControllerBaseExtensionsTest.cs
@@ -54,6 +54,11 @@
             {
                 return this.RequestTimeout();
             }
+
+            public IActionResult TestImATeapotResult()
+            {
+                return this.ImATeapot();
+            }
         }
     }
 }

--- a/test/AspNetCore.Mvc.HttpActionResults.ServerError.Test/AspNetCore.Mvc.HttpActionResults.ServerError.Test.xproj
+++ b/test/AspNetCore.Mvc.HttpActionResults.ServerError.Test/AspNetCore.Mvc.HttpActionResults.ServerError.Test.xproj
@@ -4,7 +4,6 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>4f753c9c-8146-48c4-bfef-6bc0b6e62da9</ProjectGuid>
@@ -13,9 +12,11 @@
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/AspNetCore.Mvc.HttpActionResults.ServerError.Test/ServerErrorControllerBaseExtensionsTest.cs
+++ b/test/AspNetCore.Mvc.HttpActionResults.ServerError.Test/ServerErrorControllerBaseExtensionsTest.cs
@@ -28,6 +28,31 @@
         }
 
         [Fact]
+        public void ServiceUnavailableShouldReturnServiceUnavailableResult()
+        {
+            var controller = new HomeController();
+
+            var result = controller.TestServiceUnavailableResult();
+
+            Assert.NotNull(result);
+            Assert.IsAssignableFrom<ServiceUnavailableResult>(result);
+        }
+
+        [Fact]
+        public void ServiceUnavailableShouldReturnServiceUnavailableResultWithLengthOfDelay()
+        {
+            var controller = new HomeController();
+
+            var lengthOfDelay = "10";
+            var result = controller.TestServiceUnavailableResultWithLengthOfDelay(lengthOfDelay);
+
+            Assert.NotNull(result);
+            Assert.IsAssignableFrom<ServiceUnavailableResult>(result);
+            var actionResult = (ServiceUnavailableResult)result;
+            Assert.Equal(actionResult.LengthOfDelay, lengthOfDelay);
+        }
+
+        [Fact]
         public void GatewayTimeoutShouldReturnGatewayTimeoutResult()
         {
             var controller = new HomeController();
@@ -48,6 +73,16 @@
             public IActionResult TestBadGatewayResult()
             {
                 return this.BadGateway();
+            }
+
+            public IActionResult TestServiceUnavailableResult()
+            {
+                return this.ServiceUnavailable();
+            }
+
+            public IActionResult TestServiceUnavailableResultWithLengthOfDelay(string lengthOfDelay)
+            {
+                return this.ServiceUnavailable(lengthOfDelay);
             }
 
             public IActionResult TestGatewayTimeoutResult()

--- a/test/AspNetCore.Mvc.HttpActionResults.ServerError.Test/ServerErrorControllerBaseExtensionsTest.cs
+++ b/test/AspNetCore.Mvc.HttpActionResults.ServerError.Test/ServerErrorControllerBaseExtensionsTest.cs
@@ -63,6 +63,20 @@
             Assert.IsAssignableFrom<GatewayTimeoutResult>(result);
         }
 
+        [Fact]
+        public void HTTPVersionNotSupportedShouldReturnHTTPVersionNotSupportedResult()
+        {
+            var controller = new HomeController();
+            var value = new object { };
+
+            var result = controller.TestHTTPVersionNotSupportedResult(value);
+
+            Assert.NotNull(result);
+            Assert.IsAssignableFrom<HTTPVersionNotSupportedResult>(result);
+            var actionResult = (HTTPVersionNotSupportedResult)result;
+            Assert.Equal(actionResult.Value, value);
+        }
+
         private class HomeController : ControllerBase
         {
             public IActionResult TestNotImplementedResult()
@@ -88,6 +102,11 @@
             public IActionResult TestGatewayTimeoutResult()
             {
                 return this.GatewayTimeout();
+            }
+
+            public IActionResult TestHTTPVersionNotSupportedResult(object value)
+            {
+                return this.HTTPVersionNotSupported(value);
             }
         }
     }


### PR DESCRIPTION
With 503 a Header is sent, but I couldn't think of a smart way to test it. For now I am just checking if the string is sent correctly to the Result and is set to its property, but I don't know how to check if it is sent as a Response.Header.
With 505 an information of why a certain protocol is not supported by the server and what other protocols are supported must be sent. I just made the Result accept an object like I saw it in 412 Precondition Failed.
